### PR TITLE
Bugfix in choices-guide logout function

### DIFF
--- a/src/choices-guide/component/choices-guide-result.jsx
+++ b/src/choices-guide/component/choices-guide-result.jsx
@@ -278,7 +278,9 @@ export default class OpenStadComponentChoicesGuideResult extends OpenStadCompone
 
   }
   
-  logout({ afterUrl = self.config.afterUrl }) {
+  logout({ afterUrl }) {
+
+    let self = this;
     let logoutUrl = self.config.logoutUrl || '/oauth/logout';
     
     fetch(logoutUrl, {


### PR DESCRIPTION
Choices guide logout function resulted in an error. Because of that the 'next' button after a for submit seemed to fail